### PR TITLE
Add guards for saltLength and number of words to example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ npm-*.log
 dist
 coverage
 src/_data.ts
-demo/package-lock.json
+example/package-lock.json

--- a/example/index.js
+++ b/example/index.js
@@ -27,7 +27,7 @@ const server = http.createServer((req, res) => {
 })
 
 const port = process.env.PORT || 5000
-const host = process.env.HOST || "0.0.0.0"
+const host = process.env.HOST || "localhost"
 
 server.listen(port, host, () => {
 	console.log(`=> running at http://${host}:${port}`)

--- a/example/index.js
+++ b/example/index.js
@@ -2,13 +2,15 @@ const http = require("http")
 const url = require("url")
 const namor = require("namor")
 
+const maxWords = 4
+
 const server = http.createServer((req, res) => {
 	const { query } = url.parse(req.url, true)
 
 	const payload = JSON.stringify(
 		{
 			generated_name: namor.generate({
-				words: query.words,
+				words: Math.min(query.words, maxWords),
 				saltLength: query.saltLength,
 				saltType: query.saltType,
 				separator: query.separator,

--- a/example/index.js
+++ b/example/index.js
@@ -3,6 +3,7 @@ const url = require("url")
 const namor = require("namor")
 
 const maxWords = 4
+const maxSaltLength = 20
 
 const server = http.createServer((req, res) => {
 	const { query } = url.parse(req.url, true)
@@ -11,7 +12,7 @@ const server = http.createServer((req, res) => {
 		{
 			generated_name: namor.generate({
 				words: Math.min(query.words, maxWords),
-				saltLength: query.saltLength,
+				saltLength: Math.min(query.saltLength, maxSaltLength),
 				saltType: query.saltType,
 				separator: query.separator,
 				subset: query.subset,


### PR DESCRIPTION
The example crashes if somebody uses a number greater than 4 for the `words` parameter. This PR fixes that by using the lower value of a) 4, and b) the user's `words` parameter as the actual `words` parameter in the example.

The example also crashes if somebody uses a saltLength that causes the final result to be longer than 63 characters. This PR fixes that by limiting the maximum salt length in the example to 20. This appears to never create a final subdomain longer than 63 characters.

Both crashes are because of the TypeErrors thrown in the `generator` function. I assume these TypeErrors are what caused the Heroku app to crash in #18

I've only made changes to the example and not to the underlying generator function.

While I was there, I also corrected the path in the example's `.gitignore` to the example's `package-lock.json`. The fallback host of 0.0.0.0 also didn't work on my machine so I changed it to `localhost`.